### PR TITLE
Make Google fonts "Lato" and "Raleway" website-local fonts

### DIFF
--- a/ClubSite/Pages/_Layout.cshtml
+++ b/ClubSite/Pages/_Layout.cshtml
@@ -23,7 +23,7 @@
     <meta name="generator" value="axuno piranha cms https://axuno.net (clubsite: @Piranha.Utils.GetAssemblyVersion(typeof(Program).Assembly), piranha: @Piranha.Utils.GetAssemblyVersion(typeof(Piranha.App).Assembly))" />
     @await RenderSectionAsync("head", false)
     <link rel="stylesheet" href="~/assets/css/bootstrap.min.css" asp-append-version="true">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400&family=Raleway:wght@700&display=swap">
+    <link rel="stylesheet" href="~/assets/fonts/fonts-lato-raleway.css">
     <link rel="stylesheet" href="~/assets/css/style.min.css" asp-append-version="true">
     <link href="~/assets/css/fontawesome/fontawesome.min.css" asp-append-version="true" rel="stylesheet">
     @await RenderSectionAsync("styles", false)


### PR DESCRIPTION
#### Original style sheet integration:
https://fonts.googleapis.com/css2?family=Lato:wght@300;400&family=Raleway:wght@700&display=swap

#### New local fonts stored under
wwwroot/assets/fonts

#### Other
Make BS5 variable "$light" equal to "$gray400"