### PR TITLE
Fix: NLog configuration for `AtomicFile`

### DIFF
--- a/ClubSite/Configuration/NLog.Development.config
+++ b/ClubSite/Configuration/NLog.Development.config
@@ -10,38 +10,36 @@
     <extensions>
         <!-- Make these renderers available: https://nlog-project.org/config/?tab=layout-renderers&search=package:nlog.web.aspnetcore -->
         <add assembly="NLog.Web.AspNetCore" />
+        <!-- AtomicFile must have target type AtomFile -->
         <add assembly="NLog.Targets.AtomicFile"/>
     </extensions>
 
     <!-- the targets to write to -->
     <targets async="true">
         <!-- write logs to file ** ${var:logDirectory} is set in Program.Main() -->
-        <target xsi:type="File" name="allfile" fileName="${var:logDirectory}logs\nlog-all-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="allfile" fileName="${var:logDirectory}logs\nlog-all-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=ToString,StackTrace}" />
 
         <!-- "sign-in" file log -->
-        <target xsi:type="File" name="signInFile-web" fileName="${var:logDirectory}logs\nlog-signin-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="signInFile-web" fileName="${var:logDirectory}logs\nlog-signin-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message}" />
 
         <!-- "not found" file log, only own logs. -->
-        <target xsi:type="File" name="notFoundFile-web" fileName="${var:logDirectory}logs\nlog-not-found-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="notFoundFile-web" fileName="${var:logDirectory}logs\nlog-not-found-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message}" />
 
         <!-- another file log, only own logs. -->
-        <target xsi:type="File" name="ownFile-web" fileName="${var:logDirectory}logs\nlog-own-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="ownFile-web" fileName="${var:logDirectory}logs\nlog-own-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=ToString,StackTrace}${newline}   |url: ${aspnet-request-url}|action: ${aspnet-mvc-action}" />
-
-        <!-- write to void i.e. just remove -->
-        <target xsi:type="Null" name="nowhere" />
     </targets>
 
     <!-- rules to map from logger name to target -->
     <rules>
         <!-- All logs, including from Microsoft -->
-        <logger name="*" minlevel="Info" writeTo="allfile" />
+        <logger name="*" finalMinLevel="Warn" writeTo="allfile" />
 
         <!--Skip non-critical Microsoft logs and so log only own logs-->
-        <logger name="Microsoft.*" maxlevel="Info" writeTo="nowhere" final="true" />
+        <logger name="Microsoft.*" finalMinLevel="Warn" />
         <!-- Other log content -->
         <logger name="Piranha.*" minlevel="Info" writeTo="ownFile-web" final="true" />
         <logger name="ClubSite.Areas.Manager.Pages.LoginModel" minlevel="Info" writeTo="signInFile-web" final="true" />

--- a/ClubSite/Configuration/NLog.Production.config
+++ b/ClubSite/Configuration/NLog.Production.config
@@ -10,29 +10,27 @@
     <extensions>
         <!-- Make these renderers available: https://nlog-project.org/config/?tab=layout-renderers&search=package:nlog.web.aspnetcore -->
         <add assembly="NLog.Web.AspNetCore" />
+        <!-- AtomicFile must have target type AtomFile -->
         <add assembly="NLog.Targets.AtomicFile"/>
     </extensions>
 
     <!-- the targets to write to -->
     <targets async="true">
         <!-- write logs to file ** ${var:logDirectory} is set in Program.Main() -->
-        <target xsi:type="File" name="allfile" fileName="${var:logDirectory}logs\nlog-all-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="allfile" fileName="${var:logDirectory}logs\nlog-all-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=ToString,StackTrace}" />
 
         <!-- "sign-in" file log -->
-        <target xsi:type="File" name="signInFile-web" fileName="${var:logDirectory}logs\nlog-signin-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="signInFile-web" fileName="${var:logDirectory}logs\nlog-signin-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message}" />
 
         <!-- "not found" file log -->
-        <target xsi:type="File" name="notFoundFile-web" fileName="${var:logDirectory}logs\nlog-not-found-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="notFoundFile-web" fileName="${var:logDirectory}logs\nlog-not-found-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message}" />
 
         <!-- another file log, only own logs. -->
-        <target xsi:type="File" name="ownFile-web" fileName="${var:logDirectory}logs\nlog-own-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
+        <target xsi:type="AtomFile" name="ownFile-web" fileName="${var:logDirectory}logs\nlog-own-${shortdate}.log" keepFileOpen="true" openFileCacheTimeout="5"
                 layout="${aspnet-request:header=JSNLog-RequestId:whenEmpty=${aspnet-TraceIdentifier}} ${longdate}|${event-properties:item=EventId.Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=ToString,StackTrace}${newline}   |url: ${aspnet-request-url}|action: ${aspnet-mvc-action}" />
-
-        <!-- write to void i.e. just remove -->
-        <target xsi:type="Null" name="nowhere" />
     </targets>
 
     <!-- rules to map from logger name to target -->
@@ -41,7 +39,7 @@
         <logger name="*" minlevel="Warn" writeTo="allfile" />
 
         <!--Skip non-critical Microsoft logs and so log only own logs-->
-        <logger name="Microsoft.*" maxlevel="Warn" writeTo="nowhere" final="true" />
+        <logger name="Microsoft.*" finalMinLevel="Warn" />
         <!-- Other log content -->
         <logger name="Piranha.*" minlevel="Warn" writeTo="ownFile-web" final="true" />
         <logger name="ClubSite.Areas.Manager.Pages.LoginModel" minlevel="Info" writeTo="signInFile-web" final="true" />


### PR DESCRIPTION
* `NLog.Targets.AtomicFile` must use target type `AtomFile` instead of `File`
* See [comment to PR](https://github.com/axuno/ClubSite/pull/54#issuecomment-3109836446)