### PR TITLE
feat: Update NuGet package dependencies

### DIFF
--- a/ClubSite/ClubSite.csproj
+++ b/ClubSite/ClubSite.csproj
@@ -17,11 +17,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="EPPlus" Version="8.5.3" />
-    <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="NLog.Targets.AtomicFile" Version="6.1.2" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="EPPlus" Version="8.6.1" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="NLog.Targets.AtomicFile" Version="6.1.3" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageReference Include="Piranha" Version="12.0.1" /><!-- This is a locally compiled pkg of v12.1.0 -->
     <PackageReference Include="Piranha.AspNetCore" Version="12.0.0" />
     <PackageReference Include="Piranha.AspNetCore.Identity" Version="12.0.0" />
@@ -33,13 +33,13 @@
     <PackageReference Include="Piranha.Local.FileStorage" Version="12.0.0" />
     <PackageReference Include="Piranha.Manager" Version="12.0.0" />
     <PackageReference Include="Piranha.Manager.TinyMCE" Version="12.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.23" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\StatusCodes.Designer.cs">


### PR DESCRIPTION
- Updated Microsoft.VisualStudio.Web.CodeGeneration.Design from 9.0.0 to 8.0.23
- Updated Microsoft.Build from 17.10.4 to 17.11.48
- Updated Microsoft.Build.Framework from 17.10.4 to 17.11.48
- Updated Microsoft.DotNet.Scaffolding.Shared from 9.0.0 to 8.0.23
- Updated Microsoft.NET.StringTools from 17.10.4 to 17.11.48
- Updated Microsoft.VisualStudio.Web.CodeGeneration from 9.0.0 to 8.0.23
- Updated Microsoft.VisualStudio.Web.CodeGeneration.Core from 9.0.0 to 8.0.23
- Updated Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore from 9.0.0 to 8.0.23
- Updated Microsoft.VisualStudio.Web.CodeGeneration.Templating from 9.0.0 to 8.0.23
- Updated Microsoft.VisualStudio.Web.CodeGeneration.Utils from 9.0.0 to 8.0.23
- Updated Microsoft.VisualStudio.Web.CodeGenerators.Mvc from 9.0.0 to 8.0.23